### PR TITLE
modify topic name for rviz use

### DIFF
--- a/ExampleCode/resource/sensor_fusion.properties
+++ b/ExampleCode/resource/sensor_fusion.properties
@@ -1,6 +1,6 @@
 
 topic.VisionSensor=VisionTopic
-topic.Lidar=LidarTopic
+topic.Lidar=rt/LidarTopic
 topic.out=SensorObjects
 qos.Library=Demo_Library
 qos.vision.Profile=Vision_Profile


### PR DESCRIPTION
Correcting a mistake: the updated .resource file for sensorfusion was omitted from the previous commit, resulting in the LiDAR publisher and subscriber having different topic names.   This is the updated file, now they'll both have a topic name of "rt/LidarTopic", which is compatible with the RViz 3D visualizer in ROS2.